### PR TITLE
add dynamic batching and preferred batch size for deepmet and deeptau

### DIFF
--- a/models/deepmet/config.pbtxt
+++ b/models/deepmet/config.pbtxt
@@ -36,3 +36,6 @@ output [
 ]
 
 version_policy: { all { }}
+dynamic_batching {
+    preferred_batch_size: [ 8, 16 ]
+}

--- a/models/deeptau_nosplit/config.pbtxt
+++ b/models/deeptau_nosplit/config.pbtxt
@@ -45,3 +45,6 @@ output [
     dims: [ 4 ]
   }
 ]
+dynamic_batching {
+    preferred_batch_size: [ 16, 32 ]
+}


### PR DESCRIPTION
PR to enable the dynamic batching and set the preferred batch size for deepmet and deeptau. Results came from perf_client scan of different batch sizes and picking the one with the highest throughput.