### PR TITLE
temporary fix for onnx models

### DIFF
--- a/models/particlenet/config.pbtxt
+++ b/models/particlenet/config.pbtxt
@@ -44,3 +44,4 @@ output [
     label_filename: "particlenet_labels.txt"
   }
 ]
+optimization {graph : {level : -1}}

--- a/models/particlenet_AK4/config.pbtxt
+++ b/models/particlenet_AK4/config.pbtxt
@@ -44,3 +44,4 @@ output [
     label_filename: "particlenet_labels.txt"
   }
 ]
+optimization {graph : {level : -1}}

--- a/models/particlenet_AK8_MD-2prong/config.pbtxt
+++ b/models/particlenet_AK8_MD-2prong/config.pbtxt
@@ -44,3 +44,4 @@ output [
     label_filename: "particlenet_labels.txt"
   }
 ]
+optimization {graph : {level : -1}}

--- a/models/particlenet_AK8_MassRegression/config.pbtxt
+++ b/models/particlenet_AK8_MassRegression/config.pbtxt
@@ -44,3 +44,4 @@ output [
     label_filename: "particlenet_labels.txt"
   }
 ]
+optimization {graph : {level : -1}}


### PR DESCRIPTION
Tried with the latest onnx version (1.15.1) but still having the same issue when running on GPUs (CPUs are always running fine):
```
2023-09-02 02:56:41.395682588 [E:onnxruntime:log, cuda_call.cc:116 CudaCall] CUDNN failure 3: CUDNN_STATUS_BAD_PARAM ; GPU=0 ; hostname=ailab02.fnal.gov ; file=/workspace/onnxruntime/onnxruntime/contrib_ops/cuda/fused_conv.cc ; line=85 ; expr=cudnnAddTensor(cudnnHandle, &alpha, Base::s_.z_tensor, Base::s_.z_data, &alpha, Base::s_.y_tensor, Base::s_.y_data); 
2023-09-02 02:56:41.395756473 [E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] Non-zero status code returned while running FusedConv node. Name:'Conv_88' Status Message: CUDNN failure 3: CUDNN_STATUS_BAD_PARAM ; GPU=0 ; hostname=ailab02.fnal.gov ; file=/workspace/onnxruntime/onnxruntime/contrib_ops/cuda/fused_conv.cc ; line=85 ; expr=cudnnAddTensor(cudnnHandle, &alpha, Base::s_.z_tensor, Base::s_.z_data, &alpha, Base::s_.y_tensor, Base::s_.y_data); 
```

One quick fix is to disable the graph optimizations, found from https://github.com/triton-inference-server/server/issues/3418#issuecomment-932193895

tested and confirmed they work now on GPUs. PRed the updates in the model config file.